### PR TITLE
[WIP] Indexing exploration + embedbase >0.7.5 sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "ava",
-  "version": "2.18.3",
+  "version": "2.18.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ava",
-      "version": "2.18.3",
+      "version": "2.18.6",
       "license": "MIT",
       "dependencies": {
         "@heroicons/react": "^2.0.13",
-        "embeddings-splitter": "^0.0.5",
         "lodash": "^4.17.21",
         "posthog-js": "^1.37.0",
         "react": "^18.2.0",
@@ -55,11 +54,6 @@
         "style-mod": "^4.0.0",
         "w3c-keyname": "^2.2.4"
       }
-    },
-    "node_modules/@dqbd/tiktoken": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@dqbd/tiktoken/-/tiktoken-0.2.1.tgz",
-      "integrity": "sha512-Nw9Swn37xZLAvz64qA3tTxy4yJLMhYDj7dWS6uSoHkUJxTn+BcYA+r06O36Q3Jya52b3SvK/LDXzl1dVeHqrew=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.16.14",
@@ -1434,14 +1428,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/embeddings-splitter": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/embeddings-splitter/-/embeddings-splitter-0.0.5.tgz",
-      "integrity": "sha512-+AH6MUphIcsM0AsrRbWjYlLEWX+CAA/U/szOsXr0fqvo5ITvzYqXB9rUivnRKm3UF3IAN6v60JYaospP7MdyBA==",
-      "dependencies": {
-        "@dqbd/tiktoken": "^0.2.1"
       }
     },
     "node_modules/error-ex": {
@@ -5324,11 +5310,6 @@
         "w3c-keyname": "^2.2.4"
       }
     },
-    "@dqbd/tiktoken": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@dqbd/tiktoken/-/tiktoken-0.2.1.tgz",
-      "integrity": "sha512-Nw9Swn37xZLAvz64qA3tTxy4yJLMhYDj7dWS6uSoHkUJxTn+BcYA+r06O36Q3Jya52b3SvK/LDXzl1dVeHqrew=="
-    },
     "@esbuild/android-arm": {
       "version": "0.16.14",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.14.tgz",
@@ -6222,14 +6203,6 @@
       "peer": true,
       "requires": {
         "esutils": "^2.0.2"
-      }
-    },
-    "embeddings-splitter": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/embeddings-splitter/-/embeddings-splitter-0.0.5.tgz",
-      "integrity": "sha512-+AH6MUphIcsM0AsrRbWjYlLEWX+CAA/U/szOsXr0fqvo5ITvzYqXB9rUivnRKm3UF3IAN6v60JYaospP7MdyBA==",
-      "requires": {
-        "@dqbd/tiktoken": "^0.2.1"
       }
     },
     "error-ex": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "license": "MIT",
   "dependencies": {
     "@heroicons/react": "^2.0.13",
-    "embeddings-splitter": "^0.0.5",
     "lodash": "^4.17.21",
     "posthog-js": "^1.37.0",
     "react": "^18.2.0",

--- a/src/CheckBox.tsx
+++ b/src/CheckBox.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+interface CheckBoxProps {
+    label: string;
+    subText: string;
+    checked: boolean;
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+export const CheckBox = ({ label, subText, checked, onChange }: CheckBoxProps) => {
+    return (
+        <div className="flex  items-center">
+            <input
+                aria-describedby="comments-description"
+                name="comments"
+                id="comments"
+                type="checkbox"
+                className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 cursor-pointer"
+                onChange={onChange}
+                checked={checked}
+            />
+            <div className="ml-3 text-sm">
+                <label htmlFor="comments" className="font-medium cursor-pointer">
+                    {label}
+                    <div id="comments-description" className="text-gray-500">
+                        {subText}
+                    </div>
+                </label>
+            </div>
+        </div>
+    );
+}
+

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,5 @@
 // TODO: firebase hosting custom domain name does not work with SSE somehow?
 export const API_HOST = process.env.API_HOST || "https://obsidian-ai-c6txy76x2q-uc.a.run.app";
-export const EMBEDBASE_URL = "https://embedbase-internal-c6txy76x2q-uc.a.run.app";
 
 export const buildHeaders = (token: string, version: string) => ({
     'Content-Type': 'application/json',

--- a/src/indexing.ts
+++ b/src/indexing.ts
@@ -1,0 +1,36 @@
+// import { merge, split } from 'embeddings-splitter';
+
+
+/**
+ * This function split a list of files into chunks to be indexed by
+ * an embeddings API.
+ */
+export const prepareFilesToEmbed = (files: { path?: string, content: string }[]) => {
+    const markdownHeadingRegex = /^#/;
+
+    let entries = [];
+    for (const markdownFile of files) {
+        const markdownContent = markdownFile.content;
+        const markdownEntriesPerFile = [];
+        for (const entry of markdownContent.split(markdownHeadingRegex)) {
+            const prefix = entry.startsWith('#') ? '#' : '# ';
+            if (entry.trim() !== '') {
+                markdownEntriesPerFile.push(`${prefix}${entry.trim()}`);
+            }
+        }
+        entries.push(...markdownEntriesPerFile.map((entry) => JSON.stringify((
+            markdownFile.path ?
+                { content: entry, path: markdownFile.path } :
+                { content: entry }
+        ))));
+    }
+    // HACK: atm remove too long entries until we have a better solution
+    // to properly index them (either average embeddings or split smartly in the client)
+    const maxEntryLength = 2000; // should use tokens once tiktoken works on browser
+    entries = entries.filter((entry) => entry.length < maxEntryLength);
+    // HACK
+
+    console.log(`Split ${files.length} files into ${entries.length} entries`);
+    console.log(entries);
+    return entries;
+};

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,16 +1,17 @@
 import { App } from "obsidian";
 import { complete, getCompleteFiles, search } from "./utils";
+import { AvaSettings } from "./LegacySettings";
 
 // TODO: make it work on browser
 // import { merge } from 'embeddings-splitter';
 const maxLen = 1800; // TODO: probably should be more with string length
 // TODO: very experimental
-export const createContext = async (question: string, token: string, vaultId: string, version: string, app: App) => {
-    const [searchResponse, files] = await Promise.all([search(question, token, vaultId, version), getCompleteFiles(app)]);
+export const createContext = async (question: string, settings: AvaSettings, version: string, app: App) => {
+    const [searchResponse, files] = await Promise.all([search(question, settings, version), getCompleteFiles(app)]);
     let curLen = 0;
     const returns = [];
     for (const similarity of searchResponse["similarities"]) {
-        const sentence = files.find((file) => file.path === similarity["id"])?.content;
+        const sentence = files.find((file) => file.path === similarity.path)?.content;
         // const nTokens = enc.encode(sentence).length;
         const nChars = sentence?.length || 0;
         // curLen += nTokens + 4;
@@ -25,11 +26,11 @@ export const createContext = async (question: string, token: string, vaultId: st
     // return merge(searchResponse["similarities"].map((similarity) => similarity["data"]));
 }
 
-export const generativeSearch = async (question: string, token: string, vaultId: string, version: string, app: App) => {
-    const context = await createContext(question, token, vaultId, version, app);
+export const generativeSearch = async (question: string, settings: AvaSettings, version: string, app: App) => {
+    const context = await createContext(question, settings, version, app);
     const newPrompt = `Answer the question based on the context below, and if the question can't be answered based on the context, say "I don't know"\n\nContext: ${context}\n\n---\n\nQuestion: ${question}\nAnswer:`;
     console.log('generativeSearch', newPrompt);
-    return complete(newPrompt, token, version, {
+    return complete(newPrompt, settings.token, version, {
         stream: true,
     });
 };

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,6 +1,6 @@
 import { Editor } from 'obsidian';
 import create from 'zustand/vanilla';
-import { AvaSettings } from './LegacySettings';
+import { AvaSettings, DEFAULT_SETTINGS } from './LegacySettings';
 import { ISimilarFile, LinksStatus } from './utils';
 
 type State = {
@@ -28,15 +28,7 @@ type State = {
 
 export const store = create<State>((set) => ({
   version: '',
-  settings: {
-    useLinks: false,
-    debug: false,
-    token: '',
-    vaultId: '',
-    userId: '',
-    experimental: false,
-    ignoredFolders: [],
-  },
+  settings: DEFAULT_SETTINGS,
   // used to dispaly loading state in the sidebar
   loadingEmbeds: false,
   // used to display loading state in the


### PR DESCRIPTION
# TLDR
- sync [Embedbase](https://github.com/different-ai/embedbase)@0.7.5
- added dev settings
- different indexing (exploration)
- option to ask embedbase to store the data (I want to query my index outside obsidian)

---

This is a bit overloaded PR, sorry about that, I think the indexing part should be improved before merge (and also we need to deploy https://github.com/different-ai/embedbase-ava with >embedbase@0.7.5 and switch to Supabase back-end at once)



![image](https://user-images.githubusercontent.com/25003283/224549819-99307b3d-5f84-41f9-aea2-de7b45de681b.png)

I'm using this branch for my vault and using `https://embedbase-ava-dev-c6txy76x2q-uc.a.run.app` as Embedbase instance that is using Supabase

The indexing is trying to split markdown by headers and we embed a JSON directly

e.g.

note path: "Dogs.md"
note content: "# Dogs\n\nDogs are nice, why?\n- They evolved to be best human's friend!"

`{"content": "# Dogs\n\nDogs are nice, why?\n- They evolved to be best human's friend!", "path": "Dogs.md"}`

# TODOs before merging
- [ ] improve the indexing (use https://github.com/different-ai/embeddings-utils)
  - [ ] deal properly with large documents
- [ ] deploy https://github.com/different-ai/embedbase-ava on production with Supabase & (ping everyone that they have to index their vault again OR implement a painful migration from Pinecone)

# Trying this branch
- build the code and throw main.js in your vault
- use `https://embedbase-ava-dev-c6txy76x2q-uc.a.run.app` as embedbase api in settings

